### PR TITLE
Fixed not reading right joystick factory calibration with pro controller

### DIFF
--- a/joycon-driver/include/Joycon.hpp
+++ b/joycon-driver/include/Joycon.hpp
@@ -473,7 +473,9 @@ public:
 			stick_cal_x_l[2] = stick_cal_x_l[1] + ((factory_stick_cal[1] << 8) & 0xF00 | factory_stick_cal[0]);
 			stick_cal_y_l[2] = stick_cal_y_l[1] + ((factory_stick_cal[2] << 4) | (factory_stick_cal[2] >> 4));
 		
-		} else if (this->left_right == 2 || this->left_right == 3) {
+		}
+		
+		if (this->left_right == 2 || this->left_right == 3) {
 			stick_cal_x_r[1] = (factory_stick_cal[10] << 8) & 0xF00 | factory_stick_cal[9];
 			stick_cal_y_r[1] = (factory_stick_cal[11] << 4) | (factory_stick_cal[10] >> 4);
 			stick_cal_x_r[0] = stick_cal_x_r[1] - ((factory_stick_cal[13] << 8) & 0xF00 | factory_stick_cal[12]);


### PR DESCRIPTION
The right joystick factory calibration data is not read when the connected controller is a pro controller, this patch makes the driver read both the left and right stick factory config when a pro controller in use.